### PR TITLE
elipses causing errors

### DIFF
--- a/islandora_namespace_homepage.module
+++ b/islandora_namespace_homepage.module
@@ -108,7 +108,7 @@ function namespace_homepage_page($namespace) {
 
 /**
  * Implements hook_theme().
- * 
+ *
  */
 function islandora_namespace_homepage_theme($existing, $type, $theme, $path) {
   return array(
@@ -124,7 +124,7 @@ function islandora_namespace_homepage_theme($existing, $type, $theme, $path) {
  *
  * When a new collection object is ingested, check to see if the namespace
  * prefix is already cached in the variables table.
- * 
+ *
  * If not, trigger a menu_rebuild(), which will in turn call this module's
  * hook_menu() which will refresh the list of known prefixes.
  */
@@ -229,7 +229,7 @@ function islandora_namespace_homepage_form_user_login_block_alter(&$form, &$form
 
 /**
  * Implements hook_islandora_object_access
- * 
+ *
  * @param type $op
  * @param type $object
  * @param type $user
@@ -265,7 +265,7 @@ function islandora_namespace_homepage_field_access($op, $field, $entity_type, $e
 }
 
 /**
- * 
+ *
  * @param type $user
  * @return array
  */
@@ -426,10 +426,12 @@ function islandora_namespace_homepage_islandora_breadcrumbs_alter(&$breadcrumbs,
   $title = inh_title($prefix);
   $prefix_home = "<a href='/$prefix'>$title</a>";
   foreach ($breadcrumbs as $key => $b) {
+    if($b != '...'){
     $xml = simplexml_load_string($b);
     $href = (string)$xml['href'];
     if ($href == '/islandora') {
       $breadcrumbs[$key] = $prefix_home;
+    }
     }
   }
 }


### PR DESCRIPTION
I'm not sure why some of the breadcrumbs coming through my box had a value of '...', but I added a conditional to check for them which prevented the errors I experienced.

